### PR TITLE
Alias support

### DIFF
--- a/crates/definitions/src/data.rs
+++ b/crates/definitions/src/data.rs
@@ -299,6 +299,7 @@ pub const TOKENS: Tokens<'_> = Tokens {
 };
 
 pub const SYNTAX_NODES: &'_ [SyntaxNode<'_>] = &[
+    S!("alias", "An Alias for columns"),
     S!("and", "Logical operator AND"),
     S!("argument", "A singular argument inside an argument list"),
     S!("argument_list", "A list of arguments inside a `FunctionInvocation`. Made of multiple `Arguments`, separated by commas"),

--- a/crates/source_gen/src/syntax/generated.rs
+++ b/crates/source_gen/src/syntax/generated.rs
@@ -16,6 +16,8 @@ use num_traits::ToPrimitive;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd, FromPrimitive, ToPrimitive)]
 #[repr(u16)]
 pub enum SyntaxKind {
+    #[doc = "An Alias for columns"]
+    Alias,
     #[doc = "Logical operator AND"]
     And,
     #[doc = "A singular argument inside an argument list"]

--- a/src/grammar/query.rs
+++ b/src/grammar/query.rs
@@ -118,7 +118,7 @@ fn parse_column_expr(p: &mut Parser) {
         p.start(SyntaxKind::ColumnExpr);
 
         parse_expr(p);
-        if p.at(T![as]) || p.at(T![quoted_ident]) {
+        if p.at(T![as]) || p.at(T![quoted_ident]) || p.at(T![unquoted_ident]) {
             parse_alias(p);
         }
 
@@ -137,7 +137,9 @@ fn parse_column_expr(p: &mut Parser) {
 fn parse_alias(p: &mut Parser) {
     p.start(SyntaxKind::Alias);
     p.eat(T![as]);
-    p.expect(T![quoted_ident]);
+    if !p.eat(T![quoted_ident]) {
+        p.expect(T![unquoted_ident]);
+    }
     p.finish()
 }
 

--- a/src/grammar/query.rs
+++ b/src/grammar/query.rs
@@ -118,11 +118,8 @@ fn parse_column_expr(p: &mut Parser) {
         p.start(SyntaxKind::ColumnExpr);
 
         parse_expr(p);
-
-        match p.current() {
-            T![as] => parse_as_alias(p),
-            T![quoted_ident] => parse_alias(p),
-            _ => (),
+        if p.at(T![as]) || p.at(T![quoted_ident]) {
+            parse_alias(p);
         }
 
         p.finish();
@@ -137,15 +134,9 @@ fn parse_column_expr(p: &mut Parser) {
     p.finish();
 }
 
-fn parse_as_alias(p: &mut Parser) {
-    p.start(SyntaxKind::Alias);
-    p.expect(T![as]);
-    p.expect(T![quoted_ident]);
-    p.finish();
-}
-
 fn parse_alias(p: &mut Parser) {
     p.start(SyntaxKind::Alias);
+    p.eat(T![as]);
     p.expect(T![quoted_ident]);
     p.finish()
 }

--- a/src/grammar/query.rs
+++ b/src/grammar/query.rs
@@ -118,7 +118,7 @@ fn parse_column_expr(p: &mut Parser) {
         p.start(SyntaxKind::ColumnExpr);
 
         parse_expr(p);
-        if p.at(T![as]) || p.at(T![quoted_ident]) || p.at(T![unquoted_ident]) {
+        if [T![as], T![quoted_ident], T![unquoted_ident]].contains(&p.current()) {
             parse_alias(p);
         }
 
@@ -137,9 +137,7 @@ fn parse_column_expr(p: &mut Parser) {
 fn parse_alias(p: &mut Parser) {
     p.start(SyntaxKind::Alias);
     p.eat(T![as]);
-    if !p.eat(T![quoted_ident]) {
-        p.expect(T![unquoted_ident]);
-    }
+    p.expect_one_of(&[T![quoted_ident], T![unquoted_ident]]);
     p.finish()
 }
 

--- a/src/grammar/query.rs
+++ b/src/grammar/query.rs
@@ -599,7 +599,7 @@ Root@0..106
     fn test_connect_by_root() {
         check(
             parse(
-                r#"SELECT last_name, CONNECT_BY_ROOT last_name,
+                r#"SELECT last_name "Employee", CONNECT_BY_ROOT last_name "Manager",
    LEVEL-1, SYS_CONNECT_BY_PATH(last_name, '/') 
    FROM employees
    WHERE LEVEL > 1 and department_id = 110
@@ -607,90 +607,96 @@ Root@0..106
                 |p| parse_query(p, false),
             ),
             expect![[r#"
-Root@0..200
-  SelectStmt@0..200
+Root@0..221
+  SelectStmt@0..221
     Keyword@0..6 "SELECT"
     Whitespace@6..7 " "
-    SelectClause@7..97
-      ColumnExpr@7..16
+    SelectClause@7..118
+      ColumnExpr@7..27
         IdentGroup@7..16
           Ident@7..16 "last_name"
-      Comma@16..17 ","
-      Whitespace@17..18 " "
-      ColumnExpr@18..43
-        Expression@18..43
-          HierarchicalOp@18..33 "CONNECT_BY_ROOT"
-          Whitespace@33..34 " "
-          IdentGroup@34..43
-            Ident@34..43 "last_name"
-      Comma@43..44 ","
-      Whitespace@44..48 "\n   "
-      ColumnExpr@48..53
-        IdentGroup@48..53
-          Ident@48..53 "LEVEL"
-      ColumnExpr@53..55
-        Integer@53..55 "-1"
-      Comma@55..56 ","
-      Whitespace@56..57 " "
-      ColumnExpr@57..97
-        FunctionInvocation@57..92
-          IdentGroup@57..76
-            Ident@57..76 "SYS_CONNECT_BY_PATH"
-          LParen@76..77 "("
-          ArgumentList@77..91
-            Argument@77..86
-              IdentGroup@77..86
-                Ident@77..86 "last_name"
-            Comma@86..87 ","
-            Whitespace@87..88 " "
-            Argument@88..91
-              QuotedLiteral@88..91 "'/'"
-          RParen@91..92 ")"
-        Whitespace@92..97 " \n   "
-    Keyword@97..101 "FROM"
-    Whitespace@101..102 " "
-    IdentGroup@102..111
-      Ident@102..111 "employees"
-    Whitespace@111..115 "\n   "
-    WhereClause@115..158
-      Keyword@115..120 "WHERE"
-      Whitespace@120..121 " "
-      Expression@121..158
-        Expression@121..131
-          IdentGroup@121..126
-            Ident@121..126 "LEVEL"
-          Whitespace@126..127 " "
-          ComparisonOp@127..128 ">"
-          Whitespace@128..129 " "
-          Integer@129..130 "1"
-          Whitespace@130..131 " "
-        LogicOp@131..134 "and"
-        Whitespace@134..135 " "
-        Expression@135..158
-          IdentGroup@135..148
-            Ident@135..148 "department_id"
-          Whitespace@148..149 " "
-          ComparisonOp@149..150 "="
-          Whitespace@150..151 " "
-          Integer@151..154 "110"
-          Whitespace@154..158 "\n   "
-    Connect@158..199
-      Keyword@158..165 "CONNECT"
-      Whitespace@165..166 " "
-      Keyword@166..168 "BY"
-      Whitespace@168..169 " "
-      Expression@169..199
-        Expression@169..187
-          HierarchicalOp@169..174 "PRIOR"
-          Whitespace@174..175 " "
-          IdentGroup@175..186
-            Ident@175..186 "employee_id"
-          Whitespace@186..187 " "
-        ComparisonOp@187..188 "="
-        Whitespace@188..189 " "
-        IdentGroup@189..199
-          Ident@189..199 "manager_id"
-    Semicolon@199..200 ";"
+        Whitespace@16..17 " "
+        Alias@17..27
+          Ident@17..27 "\"Employee\""
+      Comma@27..28 ","
+      Whitespace@28..29 " "
+      ColumnExpr@29..64
+        Expression@29..55
+          HierarchicalOp@29..44 "CONNECT_BY_ROOT"
+          Whitespace@44..45 " "
+          IdentGroup@45..54
+            Ident@45..54 "last_name"
+          Whitespace@54..55 " "
+        Alias@55..64
+          Ident@55..64 "\"Manager\""
+      Comma@64..65 ","
+      Whitespace@65..69 "\n   "
+      ColumnExpr@69..74
+        IdentGroup@69..74
+          Ident@69..74 "LEVEL"
+      ColumnExpr@74..76
+        Integer@74..76 "-1"
+      Comma@76..77 ","
+      Whitespace@77..78 " "
+      ColumnExpr@78..118
+        FunctionInvocation@78..113
+          IdentGroup@78..97
+            Ident@78..97 "SYS_CONNECT_BY_PATH"
+          LParen@97..98 "("
+          ArgumentList@98..112
+            Argument@98..107
+              IdentGroup@98..107
+                Ident@98..107 "last_name"
+            Comma@107..108 ","
+            Whitespace@108..109 " "
+            Argument@109..112
+              QuotedLiteral@109..112 "'/'"
+          RParen@112..113 ")"
+        Whitespace@113..118 " \n   "
+    Keyword@118..122 "FROM"
+    Whitespace@122..123 " "
+    IdentGroup@123..132
+      Ident@123..132 "employees"
+    Whitespace@132..136 "\n   "
+    WhereClause@136..179
+      Keyword@136..141 "WHERE"
+      Whitespace@141..142 " "
+      Expression@142..179
+        Expression@142..152
+          IdentGroup@142..147
+            Ident@142..147 "LEVEL"
+          Whitespace@147..148 " "
+          ComparisonOp@148..149 ">"
+          Whitespace@149..150 " "
+          Integer@150..151 "1"
+          Whitespace@151..152 " "
+        LogicOp@152..155 "and"
+        Whitespace@155..156 " "
+        Expression@156..179
+          IdentGroup@156..169
+            Ident@156..169 "department_id"
+          Whitespace@169..170 " "
+          ComparisonOp@170..171 "="
+          Whitespace@171..172 " "
+          Integer@172..175 "110"
+          Whitespace@175..179 "\n   "
+    Connect@179..220
+      Keyword@179..186 "CONNECT"
+      Whitespace@186..187 " "
+      Keyword@187..189 "BY"
+      Whitespace@189..190 " "
+      Expression@190..220
+        Expression@190..208
+          HierarchicalOp@190..195 "PRIOR"
+          Whitespace@195..196 " "
+          IdentGroup@196..207
+            Ident@196..207 "employee_id"
+          Whitespace@207..208 " "
+        ComparisonOp@208..209 "="
+        Whitespace@209..210 " "
+        IdentGroup@210..220
+          Ident@210..220 "manager_id"
+    Semicolon@220..221 ";"
 "#]],
             vec![],
         );

--- a/src/grammar/query.rs
+++ b/src/grammar/query.rs
@@ -119,6 +119,12 @@ fn parse_column_expr(p: &mut Parser) {
 
         parse_expr(p);
 
+        if p.at(T![quoted_ident]) {
+            p.start(SyntaxKind::Alias);
+            p.eat(T![quoted_ident]);
+            p.finish();
+        }
+
         p.finish();
 
         p.eat(T![,]);


### PR DESCRIPTION
## Summary
Add support for Aliases in queries.
## What has been done?
- Add alias as a SyntaxKind
- add function for identifier as "alias"
- add function for identifier "alias"
- adapt function for parse_column_expr
- add and adapt tests to new functionality
---
![Borat great success](http://www.quickmeme.com/img/40/40b96f717103244d7d9dea023de22820619058efade0a529f2938430963ed6c7.jpg)